### PR TITLE
Overlay management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ add_executable(uxplore_cpp
         source/Device/PhysicalDevice/PartitionTableReader.cpp
         source/Utils.cpp
         source/Device/PhysicalDevice/MountedPartition.cpp
-        source/Entry/EntryPhysicalMountedPartition.cpp source/Overlay/OverlayManager.cpp source/Overlay/OverlayManager.h)
+        source/Entry/EntryPhysicalMountedPartition.cpp source/Overlay/OverlayManager.hpp source/Overlay/ManagedOverlay.cpp source/Overlay/ManagedOverlay.h)
 
 romfs_add(uxplore_cpp "romfs")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ add_executable(uxplore_cpp
         source/Device/PhysicalDevice/PartitionTableReader.cpp
         source/Utils.cpp
         source/Device/PhysicalDevice/MountedPartition.cpp
-        source/Entry/EntryPhysicalMountedPartition.cpp)
+        source/Entry/EntryPhysicalMountedPartition.cpp source/Overlay/OverlayManager.cpp source/Overlay/OverlayManager.h)
 
 romfs_add(uxplore_cpp "romfs")
 

--- a/source/Application.cpp
+++ b/source/Application.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Application.cpp
+++ b/source/Application.cpp
@@ -40,7 +40,7 @@ Application::Application()
     m_textFont = TTF_OpenFont("romfs:/res/fonts/opensans.ttf", 32);
     ImageCache::getInstance().setRenderer(m_sdlRendererTV);
 
-    m_overlayManager.pushOverlay(std::make_unique<Browser>());
+    m_overlayManager.pushOverlay(std::make_unique<Browser>(m_overlayManager));
 }
 
 Application::~Application()

--- a/source/Application.cpp
+++ b/source/Application.cpp
@@ -40,8 +40,7 @@ Application::Application()
     m_textFont = TTF_OpenFont("romfs:/res/fonts/opensans.ttf", 32);
     ImageCache::getInstance().setRenderer(m_sdlRendererTV);
 
-    std::unique_ptr<Browser> browser(new Browser());
-    m_overlays.emplace_back(std::move(browser));
+    m_overlayManager.pushOverlay(std::make_unique<Browser>());
 }
 
 Application::~Application()
@@ -64,30 +63,22 @@ void Application::render(const float &delta)
 {
     // Poll any event and dispatch it to the most recent overlay
     SDL_Event event;
-    if (SDL_PollEvent(&event) && !m_overlays.empty()) {
-        m_overlays.back()->processEvent(event);
+    if (SDL_PollEvent(&event)) {
+        m_overlayManager.processEvent(event);
     }
 
     // Update every overlay
-    for (auto &m_overlay : m_overlays) {
-        m_overlay->update(delta);
-    }
+    m_overlayManager.update(delta);
 
     // Clear and draw the TV for every overlay
     SDL_SetRenderDrawColor(m_sdlRendererTV, 255, 255, 255, SDL_ALPHA_OPAQUE);
     SDL_RenderClear(m_sdlRendererTV);
-
-    for (auto &m_overlay : m_overlays) {
-        m_overlay->renderPrimary(*m_sdlRendererTV, *m_textFont);
-    }
+    m_overlayManager.renderPrimary(*m_sdlRendererTV, *m_textFont);
 
     // Clear and draw the DRC for every overlay
     SDL_SetRenderDrawColor(m_sdlRendererGamepad, 255, 255, 255, SDL_ALPHA_OPAQUE);
     SDL_RenderClear(m_sdlRendererGamepad);
-
-    for (auto &m_overlay : m_overlays) {
-        m_overlay->renderSecondary(*m_sdlRendererGamepad, *m_textFont);
-    }
+    m_overlayManager.renderSecondary(*m_sdlRendererGamepad, *m_textFont);
 
     SDL_RenderPresent(m_sdlRendererTV);
     SDL_RenderPresent(m_sdlRendererGamepad);

--- a/source/Application.cpp
+++ b/source/Application.cpp
@@ -19,8 +19,6 @@
 #include "Application.h"
 #include "ImageCache.h"
 #include "Overlay/Browser.h"
-#include <whb/log.h>
-#include <iosuhax.h>
 
 Application::Application()
 {
@@ -40,7 +38,7 @@ Application::Application()
     m_textFont = TTF_OpenFont("romfs:/res/fonts/opensans.ttf", 32);
     ImageCache::getInstance().setRenderer(m_sdlRendererTV);
 
-    m_overlayManager.pushOverlay(std::make_unique<Browser>(m_overlayManager));
+    m_overlayManager.pushOverlay<Browser>();
 }
 
 Application::~Application()

--- a/source/Application.h
+++ b/source/Application.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Application.h
+++ b/source/Application.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <vector>
 
-#include "Overlay/Overlay.h"
+#include "Overlay/OverlayManager.hpp"
 
 class Application {
 public:
@@ -42,7 +42,7 @@ private:
 
     std::vector<SDL_Joystick *> m_openedJoysticks;
 
-    std::vector<std::unique_ptr<Overlay>> m_overlays;
+    OverlayManager m_overlayManager;
 };
 
 #endif // APPLICATION_HPP

--- a/source/BrowseSession.cpp
+++ b/source/BrowseSession.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/BrowseSession.h
+++ b/source/BrowseSession.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/BrowserList.cpp
+++ b/source/BrowserList.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/BrowserList.h
+++ b/source/BrowserList.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Device/PhysicalDevice.cpp
+++ b/source/Device/PhysicalDevice.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Device/PhysicalDevice.h
+++ b/source/Device/PhysicalDevice.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Device/PhysicalDevice/MountedPartition.cpp
+++ b/source/Device/PhysicalDevice/MountedPartition.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Device/PhysicalDevice/MountedPartition.h
+++ b/source/Device/PhysicalDevice/MountedPartition.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Device/PhysicalDevice/PartitionTableReader.cpp
+++ b/source/Device/PhysicalDevice/PartitionTableReader.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Device/PhysicalDevice/PartitionTableReader.h
+++ b/source/Device/PhysicalDevice/PartitionTableReader.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Device/PhysicalDevice/PhyDeviceManager.cpp
+++ b/source/Device/PhysicalDevice/PhyDeviceManager.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Device/PhysicalDevice/PhyDeviceManager.h
+++ b/source/Device/PhysicalDevice/PhyDeviceManager.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Device/PhysicalDevice/PhyDeviceUtils.cpp
+++ b/source/Device/PhysicalDevice/PhyDeviceUtils.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Device/PhysicalDevice/PhyDeviceUtils.h
+++ b/source/Device/PhysicalDevice/PhyDeviceUtils.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/DiscInterface/DiscInterface.cpp
+++ b/source/DiscInterface/DiscInterface.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/DiscInterface/DiscInterface.h
+++ b/source/DiscInterface/DiscInterface.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/DiscInterface/DiscInterfaceWrapper.cpp
+++ b/source/DiscInterface/DiscInterfaceWrapper.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/DiscInterface/DiscInterfaceWrapper.h
+++ b/source/DiscInterface/DiscInterfaceWrapper.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Entry/Entry.h
+++ b/source/Entry/Entry.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Entry/EntryFile.cpp
+++ b/source/Entry/EntryFile.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Entry/EntryFile.h
+++ b/source/Entry/EntryFile.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Entry/EntryPhysicalMountedPartition.cpp
+++ b/source/Entry/EntryPhysicalMountedPartition.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Entry/EntryPhysicalMountedPartition.h
+++ b/source/Entry/EntryPhysicalMountedPartition.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/File.cpp
+++ b/source/File.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/File.h
+++ b/source/File.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/FilesystemProvider.h
+++ b/source/FilesystemProvider.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/GUI/BrowserItem.cpp
+++ b/source/GUI/BrowserItem.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/GUI/BrowserItem.h
+++ b/source/GUI/BrowserItem.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/GUI/Drawable.cpp
+++ b/source/GUI/Drawable.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/GUI/Drawable.h
+++ b/source/GUI/Drawable.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/GUI/Text.cpp
+++ b/source/GUI/Text.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/GUI/Text.h
+++ b/source/GUI/Text.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/ImageCache.cpp
+++ b/source/ImageCache.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/ImageCache.h
+++ b/source/ImageCache.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/LocalFile.cpp
+++ b/source/LocalFile.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/LocalFile.h
+++ b/source/LocalFile.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/NavigationHistory.cpp
+++ b/source/NavigationHistory.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/NavigationHistory.h
+++ b/source/NavigationHistory.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Overlay/Browser.cpp
+++ b/source/Overlay/Browser.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Overlay/Browser.cpp
+++ b/source/Overlay/Browser.cpp
@@ -28,29 +28,11 @@
 #include "BrowserList.h"
 #include "File.h"
 
-Browser::Browser()
-        : m_browseSession(m_physicalDeviceManager)
+Browser::Browser(OverlayManager &manager)
+        : ManagedOverlay(manager)
+        , m_browseSession(m_physicalDeviceManager)
 {
-    /*DIR *pdir;
-    struct dirent *pent;
-    
-    pdir=opendir("usb001:/");
-    
-    WHBLogPrint("dir opened");
-    
-    if (pdir) {
-        while ((pent=readdir(pdir))!=NULL) {
-            if(strcmp(".", pent->d_name) == 0 || strcmp("..", pent->d_name) == 0)
-                continue;
-            if(pent->d_type == DT_DIR)
-                WHBLogPrintf("[%s]", pent->d_name);
-            else
-                WHBLogPrintf("%s", pent->d_name);
-        }
-        closedir(pdir);
-    } else {
-        WHBLogPrintf("opendir() failure; terminating");
-    }*/
+
 }
 
 void Browser::update(const float &delta)

--- a/source/Overlay/Browser.cpp
+++ b/source/Overlay/Browser.cpp
@@ -18,15 +18,7 @@
 
 #include "Browser.h"
 
-#include <TweenEngine/Tween.h>
-#include <whb/log.h>
-#include <fat.h>
-
-#include "Device/PhysicalDevice/PhyDeviceUtils.h"
-#include "DiscInterface/DiscInterface.h"
-#include "Entry/EntryFile.h"
-#include "BrowserList.h"
-#include "File.h"
+#include "OverlayManager.hpp"
 
 Browser::Browser(OverlayManager &manager)
         : ManagedOverlay(manager)

--- a/source/Overlay/Browser.h
+++ b/source/Overlay/Browser.h
@@ -27,7 +27,7 @@
 
 class Browser : public ManagedOverlay {
 public:
-    Browser();
+    explicit Browser(OverlayManager &manager);
     ~Browser() override = default;
 
     void processEvent(const SDL_Event &event) override;

--- a/source/Overlay/Browser.h
+++ b/source/Overlay/Browser.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Overlay/Browser.h
+++ b/source/Overlay/Browser.h
@@ -21,11 +21,11 @@
 
 #include <TweenEngine/TweenManager.h>
 
-#include "BrowseSession.h"
-#include "Device/PhysicalDevice/PhyDeviceManager.h"
-#include "Overlay.h"
+#include "../BrowseSession.h"
+#include "../Device/PhysicalDevice/PhyDeviceManager.h"
+#include "ManagedOverlay.h"
 
-class Browser : public Overlay {
+class Browser : public ManagedOverlay {
 public:
     Browser();
     ~Browser() override = default;

--- a/source/Overlay/Dialog.cpp
+++ b/source/Overlay/Dialog.cpp
@@ -18,7 +18,9 @@
 
 #include "Dialog.h"
 
-Dialog::Dialog(std::string message)
+Dialog::Dialog(OverlayManager &manager, const std::string &message)
+    : ManagedOverlay(manager)
+    , m_message(message)
 {
 
 }

--- a/source/Overlay/Dialog.cpp
+++ b/source/Overlay/Dialog.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Overlay/Dialog.cpp
+++ b/source/Overlay/Dialog.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "Dialog.h"
+#include "OverlayManager.hpp"
 
 Dialog::Dialog(OverlayManager &manager, const std::string &message)
     : ManagedOverlay(manager)
@@ -32,12 +33,21 @@ void Dialog::update(const float &delta)
 
 void Dialog::processEvent(const SDL_Event &event)
 {
-
+    // Remove the Dialog if the B button was pressed
+    if (event.type == SDL_JOYBUTTONUP && event.jbutton.button == 1) {
+        m_overlayManager.popOverlay();
+    }
 }
 
 void Dialog::renderPrimary(SDL_Renderer &renderer, TTF_Font &font)
 {
-
+    SDL_SetRenderDrawColor(&renderer, 0, 0, 0, 0xDF);
+    SDL_Rect rect;
+    rect.x = 0;
+    rect.y = 0;
+    rect.w = 1280;
+    rect.h = 720;
+    SDL_RenderFillRect(&renderer, &rect);
 }
 
 void Dialog::renderSecondary(SDL_Renderer &renderer, TTF_Font &font)

--- a/source/Overlay/Dialog.h
+++ b/source/Overlay/Dialog.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Overlay/Dialog.h
+++ b/source/Overlay/Dialog.h
@@ -21,9 +21,9 @@
 
 #include <TweenEngine/TweenManager.h>
 
-#include "Overlay.h"
+#include "ManagedOverlay.h"
 
-class Dialog : public Overlay {
+class Dialog : public ManagedOverlay {
 public:
     explicit Dialog(std::string message);
     ~Dialog() override = default;

--- a/source/Overlay/Dialog.h
+++ b/source/Overlay/Dialog.h
@@ -25,7 +25,7 @@
 
 class Dialog : public ManagedOverlay {
 public:
-    explicit Dialog(std::string message);
+    explicit Dialog(OverlayManager &manager, const std::string &message);
     ~Dialog() override = default;
 
     void processEvent(const SDL_Event &event) override;
@@ -34,6 +34,9 @@ public:
 
     void renderPrimary(SDL_Renderer &renderer, TTF_Font &font) override;
     void renderSecondary(SDL_Renderer &renderer, TTF_Font &font) override;
+
+private:
+    std::string m_message;
 };
 
 #endif // DIALOG_HPP

--- a/source/Overlay/ManagedOverlay.cpp
+++ b/source/Overlay/ManagedOverlay.cpp
@@ -1,4 +1,4 @@
-/*Overlay
+/*
     Uxplore
     Copyright (C) 2019-2020, Kuruyia
 
@@ -16,22 +16,4 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef OVERLAY_HPP
-#define OVERLAY_HPP
-
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_ttf.h>
-
-class Overlay {
-public:
-    virtual ~Overlay() = default;
-
-    virtual void processEvent(const SDL_Event &event) = 0;
-
-    virtual void update(const float &delta) = 0;
-
-    virtual void renderPrimary(SDL_Renderer &renderer, TTF_Font &font) = 0;
-    virtual void renderSecondary(SDL_Renderer &renderer, TTF_Font &font) = 0;
-};
-
-#endif // OVERLAY_HPP
+#include "ManagedOverlay.h"

--- a/source/Overlay/ManagedOverlay.cpp
+++ b/source/Overlay/ManagedOverlay.cpp
@@ -20,17 +20,7 @@
 #include "OverlayManager.hpp"
 
 ManagedOverlay::ManagedOverlay(OverlayManager &manager)
-    : m_manager(manager)
+    : m_overlayManager(manager)
 {
 
-}
-
-void ManagedOverlay::pushOverlay(std::unique_ptr<ManagedOverlay> overlay)
-{
-    // TODO: Implement this
-}
-
-void ManagedOverlay::popOverlay()
-{
-    m_manager.popOverlay();
 }

--- a/source/Overlay/ManagedOverlay.cpp
+++ b/source/Overlay/ManagedOverlay.cpp
@@ -17,3 +17,20 @@
 */
 
 #include "ManagedOverlay.h"
+#include "OverlayManager.hpp"
+
+ManagedOverlay::ManagedOverlay(OverlayManager &manager)
+    : m_manager(manager)
+{
+
+}
+
+void ManagedOverlay::pushOverlay(std::unique_ptr<ManagedOverlay> overlay)
+{
+    // TODO: Implement this
+}
+
+void ManagedOverlay::popOverlay()
+{
+    m_manager.popOverlay();
+}

--- a/source/Overlay/ManagedOverlay.h
+++ b/source/Overlay/ManagedOverlay.h
@@ -31,12 +31,7 @@ public:
     ~ManagedOverlay() override = default;
 
 protected:
-    void pushOverlay(std::unique_ptr<ManagedOverlay> overlay);
-    void popOverlay();
-
-private:
-    OverlayManager &m_manager;
+    OverlayManager &m_overlayManager;
 };
-
 
 #endif //UXPLORE_CPP_MANAGEDOVERLAY_H

--- a/source/Overlay/ManagedOverlay.h
+++ b/source/Overlay/ManagedOverlay.h
@@ -1,4 +1,4 @@
-/*Overlay
+/*
     Uxplore
     Copyright (C) 2019-2020, Kuruyia
 
@@ -16,22 +16,15 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef OVERLAY_HPP
-#define OVERLAY_HPP
+#ifndef UXPLORE_CPP_MANAGEDOVERLAY_H
+#define UXPLORE_CPP_MANAGEDOVERLAY_H
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_ttf.h>
+#include "Overlay.h"
 
-class Overlay {
+class ManagedOverlay : public Overlay {
 public:
-    virtual ~Overlay() = default;
-
-    virtual void processEvent(const SDL_Event &event) = 0;
-
-    virtual void update(const float &delta) = 0;
-
-    virtual void renderPrimary(SDL_Renderer &renderer, TTF_Font &font) = 0;
-    virtual void renderSecondary(SDL_Renderer &renderer, TTF_Font &font) = 0;
+    ~ManagedOverlay() override = default;
 };
 
-#endif // OVERLAY_HPP
+
+#endif //UXPLORE_CPP_MANAGEDOVERLAY_H

--- a/source/Overlay/ManagedOverlay.h
+++ b/source/Overlay/ManagedOverlay.h
@@ -19,11 +19,23 @@
 #ifndef UXPLORE_CPP_MANAGEDOVERLAY_H
 #define UXPLORE_CPP_MANAGEDOVERLAY_H
 
+#include <memory>
+
 #include "Overlay.h"
+
+class OverlayManager;
 
 class ManagedOverlay : public Overlay {
 public:
+    explicit ManagedOverlay(OverlayManager &manager);
     ~ManagedOverlay() override = default;
+
+protected:
+    void pushOverlay(std::unique_ptr<ManagedOverlay> overlay);
+    void popOverlay();
+
+private:
+    OverlayManager &m_manager;
 };
 
 

--- a/source/Overlay/Overlay.h
+++ b/source/Overlay/Overlay.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Overlay/Overlay.h
+++ b/source/Overlay/Overlay.h
@@ -1,4 +1,4 @@
-/*Overlay
+/*
     Uxplore
     Copyright (C) 2019-2020, Kuruyia
 

--- a/source/Overlay/OverlayManager.hpp
+++ b/source/Overlay/OverlayManager.hpp
@@ -1,0 +1,65 @@
+/*
+    Uxplore
+    Copyright (C) 2019-2020, Kuruyia
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef UXPLORE_CPP_OVERLAYMANAGER_HPP
+#define UXPLORE_CPP_OVERLAYMANAGER_HPP
+
+#include <memory>
+#include <vector>
+
+#include "ManagedOverlay.h"
+
+class OverlayManager {
+public:
+    void processEvent(const SDL_Event &event) {
+        if (!m_overlayStack.empty()) {
+            m_overlayStack.back()->processEvent(event);
+        }
+    }
+
+    void update(const float &delta) {
+        for (auto &m_overlay : m_overlayStack) {
+            m_overlay->update(delta);
+        }
+    }
+
+    void renderPrimary(SDL_Renderer &renderer, TTF_Font &font) {
+        for (auto &m_overlay : m_overlayStack) {
+            m_overlay->renderPrimary(renderer, font);
+        }
+    }
+
+    void renderSecondary(SDL_Renderer &renderer, TTF_Font &font) {
+        for (auto &m_overlay : m_overlayStack) {
+            m_overlay->renderSecondary(renderer, font);
+        }
+    }
+
+    void pushOverlay(std::unique_ptr<ManagedOverlay> overlay) {
+        m_overlayStack.push_back(std::move(overlay));
+    }
+
+    void popOverlay() {
+        m_overlayStack.pop_back();
+    }
+private:
+    std::vector<std::unique_ptr<ManagedOverlay>> m_overlayStack;
+};
+
+
+#endif //UXPLORE_CPP_OVERLAYMANAGER_HPP

--- a/source/Overlay/OverlayManager.hpp
+++ b/source/Overlay/OverlayManager.hpp
@@ -50,8 +50,9 @@ public:
         }
     }
 
-    void pushOverlay(std::unique_ptr<ManagedOverlay> overlay) {
-        m_overlayStack.push_back(std::move(overlay));
+    template <typename T, typename... Args>
+    void pushOverlay(Args&&... args) {
+        m_overlayStack.push_back(std::make_unique<T>(*this, std::forward<Args>(args)...));
     }
 
     void popOverlay() {

--- a/source/TweenObjects.h
+++ b/source/TweenObjects.h
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Utils.cpp
+++ b/source/Utils.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/Utils.h
+++ b/source/Utils.h
@@ -1,7 +1,7 @@
 /*
     bool m_gptPresent;
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,6 +1,6 @@
 /*
     Uxplore
-    Copyright (C) 2019-2019, Kuruyia
+    Copyright (C) 2019-2020, Kuruyia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
These modification to the Overlay system separates the overlay stack manager to its own class, `OverlayManager`.
Along this, it adds a new class, `ManagedOverlay`, which is derived from `Overlay` and stores a reference to its manager.
Every class that derives from `ManagedOverlay` can then access its manager to push or pop an overlay to the stack.

<sub><sup>(oopsie for 84f28a9 being here)</sup></sub>